### PR TITLE
Asynchronously Load webpack Bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@babel/cli": "^7.6.4",
     "@babel/core": "^7.6.4",
     "@babel/plugin-proposal-class-properties": "^7.5.5",
+    "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "@babel/preset-env": "^7.6.3",
     "@babel/preset-react": "^7.6.3",
     "babel-loader": "^8.0.6",

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { hot } from 'react-hot-loader';
 
+const Warning = React.lazy(() => import('./warning'));
 class App extends React.Component {
   state = {
     count: 0,
@@ -23,6 +24,12 @@ class App extends React.Component {
         >
           -
         </button>
+
+        {this.state.count > 10 ? (
+          <React.Suspense fallback={null}>
+            <Warning />
+          </React.Suspense>
+        ) : null}
       </div>
     );
   }

--- a/src/warning.js
+++ b/src/warning.js
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export default () => <span className={'warning'}>take it easy</span>;

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -32,6 +32,7 @@ module.exports = {
           plugins: [
             '@babel/plugin-proposal-class-properties',
             'react-hot-loader/babel',
+            '@babel/plugin-syntax-dynamic-import',
           ],
         },
       },


### PR DESCRIPTION
Webpack has given us the ability to use this dynamic import syntax to asynchronously load modules only when we need them. By splitting our code this way, we can keep our initial bundle small, and only load things when they're required in the browser.